### PR TITLE
Specify only compatible version of http-conduit

### DIFF
--- a/elm-get.cabal
+++ b/elm-get.cabal
@@ -46,7 +46,7 @@ Executable elm-get
                        directory,
                        filepath,
                        HTTP,
-                       http-conduit,
+                       http-conduit >= 1.9, http-conduit < 2.0,
                        http-types,
                        mtl,
                        network,


### PR DESCRIPTION
I think a LOT of these build dependencies are going to need more specific versions but this was the only problem that I ran into when installing.
