### PR TITLE
Extracted readDependencies to solver environment

### DIFF
--- a/src/Utils/ResolveDeps.hs
+++ b/src/Utils/ResolveDeps.hs
@@ -208,10 +208,3 @@ solveConstraints deps =
        True ->
          let result = M.delete (D.name deps) $ ssPinnedVersions state
          in return (M.toList result)
-
-getDependenciesPure :: Map (String, V.Version) D.Deps -> String -> V.Version
-                    -> ErrorT String IO D.Deps
-getDependenciesPure env name version =
-  case M.lookup (name, version) env of
-    Just result -> return result
-    Nothing -> throwError $ "Haven't found dependencies for " ++ name ++ " (" ++ show version ++ ")"


### PR DESCRIPTION
These changes don't alter behavior of dependency solver, but are necessary to be able to change default way of how dependencies information is fetched. Thus, this change would allow to be able to run dependency solver without network access and make it testable.
