### PR TITLE
Bugfix in "elm-get install" in case of no libraries to install

### DIFF
--- a/src/Get/Install.hs
+++ b/src/Get/Install.hs
@@ -75,6 +75,7 @@ offerInstallPlan :: [(LibChange, Lib)] -> IO Bool
 offerInstallPlan ls = case ls of
   [] ->
     do putStrLn "Nothing to install"
+       writeLibraries []
        return False
   _ ->
     do putStrLn "The following libraries will be installed:"


### PR DESCRIPTION
"elm-get publish" will complain about absence of "solved-dependencies.json" file which is to be produced by "elm-get install". However, last one wouldn't write that file in case when there are no libraries to install (the library has no dependencies).

This PR fixes that bug.
