### PR TITLE
Now using "elm --generate-docs" instead of "elm-doc"

### DIFF
--- a/src/Get/Publish.hs
+++ b/src/Get/Publish.hs
@@ -146,7 +146,7 @@ verifyVersion name version =
 
 generateDocs :: [String] -> ErrorT String IO ()
 generateDocs modules =
-    do forM elms $ \path -> Cmd.run "elm-doc" [path]
+    do Cmd.run "elm" ("--generate-docs" : "--make" : elms)
        liftIO $
          do let path = Path.combinedJson
             BS.writeFile path "[\n"


### PR DESCRIPTION
Fixed documentation generation procedure to use "elm --generate-docs" to be compatible with development version of Elm
