### PR TITLE
go directly to codeload

### DIFF
--- a/src/Install/Fetch.hs
+++ b/src/Install/Fetch.hs
@@ -26,7 +26,7 @@ package name@(N.Name user _) version =
             liftIO $ renameDirectory dir (V.toString version)
   where
     zipball =
-        "http://github.com/" ++ N.toUrl name ++ "/zipball/" ++ V.toString version ++ "/"
+        "https://codeload.github.com/" ++ N.toUrl name ++ "/legacy.zip/" ++ V.toString version ++ "/"
 
 
 ifNotExists :: (MonadIO m, MonadError String m) => N.Name -> V.Version -> m () -> m ()


### PR DESCRIPTION
Resolves #92 

On some systems (specifically when behind a proxy on unix) the following 302 doesn't get resolved correctly:

https://github.com/elm-lang/core/zipball/1.1.0/

https://codeload.github.com/elm-lang/core/legacy.zip/1.1.0

So this just goes there directly.

(Not the most elegant solution, probably an issue with http-client library)