### PR TITLE
WIP Allow installation of local folders as packages

### DIFF
--- a/src/CommandLine/Arguments.hs
+++ b/src/CommandLine/Arguments.hs
@@ -125,18 +125,18 @@ installInfo =
     Opt.info args infoModifier
   where
     args =
-        installWith <$> optional package <*> optional version <*> yes
+        installWith <$> optional packageOrFolder <*> optional version <*> yes
 
     installWith maybeName maybeVersion autoYes =
         case (maybeName, maybeVersion) of
           (Nothing, Nothing) ->
               Install.install autoYes Install.Everything
 
-          (Just name, Nothing) ->
-              Install.install autoYes (Install.Latest name)
+          (Just str, Nothing) ->
+              Install.install autoYes (Install.Latest str)
 
-          (Just name, Just version) ->
-              Install.install autoYes (Install.Exactly name version)
+          (Just str, Just version) ->
+              Install.install autoYes (Install.Exactly str version)
 
           (Nothing, Just version) ->
               throwError $
@@ -167,6 +167,14 @@ package =
         mconcat
         [ Opt.metavar "PACKAGE"
         , Opt.help "A specific package name (e.g. evancz/automaton)"
+        ]
+
+packageOrFolder :: Opt.Parser String
+packageOrFolder =
+    Opt.argument (Just . id) $
+        mconcat
+        [ Opt.metavar "PACKAGE or FOLDER"
+        , Opt.help "A specific package name (e.g. evancz/automaton) or a local folder"
         ]
 
 version :: Opt.Parser V.Version

--- a/src/Elm/Package/Description.hs
+++ b/src/Elm/Package/Description.hs
@@ -41,7 +41,7 @@ data Description = Description
 defaultDescription :: Description
 defaultDescription =
     Description
-    { name = N.Name "USER" "PROJECT"
+    { name = N.Remote "USER" "PROJECT"
     , repo = "https://github.com/USER/PROJECT.git"
     , version = V.initialVersion
     , summary = "helpful summary of your project, less than 80 characters"

--- a/src/Elm/Package/Name.hs
+++ b/src/Elm/Package/Name.hs
@@ -11,7 +11,7 @@ import System.FilePath ((</>))
 
 
 data Name =
-    Name
+    Remote
         { user :: String
         , project :: String
         }
@@ -21,24 +21,24 @@ data Name =
 
 dummyName :: Name
 dummyName =
-    Name "USER" "PROJECT"
+    Remote "USER" "PROJECT"
 
 
 toString :: Name -> String
 toString name = case name of
-    Name user project -> user ++ "/" ++ project
+    Remote user project -> user ++ "/" ++ project
     Local path -> "file://" ++ path
 
 
 toUrl :: Name -> String
 toUrl name = case name of
-    Name user project -> user ++ "/" ++ project
+    Remote user project -> user ++ "/" ++ project
     Local path -> "file://" ++ path
 
 
 toFilePath :: Name -> FilePath
 toFilePath name = case name of
-    Name user project -> user </> project
+    Remote user project -> user </> project
     Local path -> path
 
 
@@ -47,7 +47,7 @@ fromString string =
     case break (=='/') string of
       ( "file:", '/':'/': path@(_:_)) -> Just (Local path)
       ( user@(_:_), '/' : project@(_:_) )
-          | all (/='/') project -> Just (Name user project)
+          | all (/='/') project -> Just (Remote user project)
       _ -> Nothing
 
 
@@ -59,9 +59,9 @@ fromString' string =
 instance Binary Name where
     get = do t <- get :: Get Word8
              case t of
-                0 -> Name <$> get <*> get
+                0 -> Remote <$> get <*> get
                 1 -> Local <$> get
-    put (Name user project) =
+    put (Remote user project) =
         do  put (0 :: Word8)
             put user
             put project

--- a/src/Elm/Package/Name.hs
+++ b/src/Elm/Package/Name.hs
@@ -57,16 +57,15 @@ fromString' string =
 
 
 instance Binary Name where
-    get = do t <- get :: Get Word8
+    get = do t <- get :: Get String
              case t of
-                0 -> Remote <$> get <*> get
-                1 -> Local <$> get
+                ("file://") -> Local <$> get
+                user        -> Remote user <$> get
     put (Remote user project) =
-        do  put (0 :: Word8)
-            put user
+        do  put user
             put project
     put (Local path) =
-        do  put (1 :: Word8)
+        do  put ("file://" :: String)
             put path
 
 

--- a/src/Elm/Package/Name.hs
+++ b/src/Elm/Package/Name.hs
@@ -27,13 +27,13 @@ dummyName =
 toString :: Name -> String
 toString name = case name of
     Remote user project -> user ++ "/" ++ project
-    Local path -> "file://" ++ path
+    Local path -> "local://" ++ path
 
 
 toUrl :: Name -> String
 toUrl name = case name of
     Remote user project -> user ++ "/" ++ project
-    Local path -> "file://" ++ path
+    Local path -> "local://" ++ path
 
 
 toFilePath :: Name -> FilePath
@@ -45,7 +45,7 @@ toFilePath name = case name of
 fromString :: String -> Maybe Name
 fromString string =
     case break (=='/') string of
-      ( "file:", '/':'/': path@(_:_)) -> Just (Local path)
+      ( "local:", '/':'/': path@(_:_)) -> Just (Local path)
       ( user@(_:_), '/' : project@(_:_) )
           | all (/='/') project -> Just (Remote user project)
       _ -> Nothing
@@ -59,13 +59,13 @@ fromString' string =
 instance Binary Name where
     get = do t <- get :: Get String
              case t of
-                ("file://") -> Local <$> get
+                ("local://") -> Local <$> get
                 user        -> Remote user <$> get
     put (Remote user project) =
         do  put user
             put project
     put (Local path) =
-        do  put ("file://" :: String)
+        do  put ("local://" :: String)
             put path
 
 

--- a/src/GitHub.hs
+++ b/src/GitHub.hs
@@ -23,7 +23,7 @@ getVersionTags
     :: (MonadIO m, MonadError String m)
     => Name.Name -> m [Version.Version]
 
-getVersionTags (Name.Name user project) =
+getVersionTags (Name.Remote user project) =
   do  response <-
           Http.send url $ \request manager ->
               httpLbs (request {requestHeaders = headers}) manager
@@ -37,6 +37,8 @@ getVersionTags (Name.Name user project) =
     headers =
         [("User-Agent", "elm-package")]
         <> [("Accept", "application/json")]
+
+getVersionTags (Name.Local _) = throwError "Local repository given to GitHub.getVersionTags"
 
 
 instance FromJSON Tags where

--- a/src/Install.hs
+++ b/src/Install.hs
@@ -196,7 +196,7 @@ showDependency name constraint =
 
 initialDescription :: Manager.Manager Desc.Description
 initialDescription =
-  do  let core = N.Name "elm-lang" "core"
+  do  let core = N.Remote "elm-lang" "core"
       version <- latestVersion core
       let desc = Desc.defaultDescription {
           Desc.dependencies = [ (core, Constraint.minimalRangeFrom version) ]

--- a/src/Install/Fetch.hs
+++ b/src/Install/Fetch.hs
@@ -15,7 +15,7 @@ import qualified Utils.Http as Http
 
 
 package :: (MonadIO m, MonadError String m) => N.Name -> V.Version -> m ()
-package name@(N.Name user _) version =
+package name@(N.Remote user _) version =
   ifNotExists name version $ do
       Http.send zipball extract
       files <- liftIO $ getDirectoryContents "."
@@ -27,6 +27,8 @@ package name@(N.Name user _) version =
   where
     zipball =
         "http://github.com/" ++ N.toUrl name ++ "/zipball/" ++ V.toString version ++ "/"
+
+package name@(N.Local path) version = undefined
 
 
 ifNotExists :: (MonadIO m, MonadError String m) => N.Name -> V.Version -> m () -> m ()

--- a/src/Install/Solver.hs
+++ b/src/Install/Solver.hs
@@ -94,7 +94,8 @@ addConstraints :: Packages -> [(N.Name, C.Constraint)] -> Explorer (Maybe Packag
 addConstraints packages constraints =
     case constraints of
       [] -> return (Just packages)
-      (name, constraint) : rest ->
+      ((N.Local _), _) : rest -> addConstraints packages rest
+      (name@(N.Remote _ _), constraint) : rest ->
           do  versions <- Store.getVersions name
               case filter (C.isSatisfied constraint) versions of
                 [] -> return Nothing

--- a/src/Store.hs
+++ b/src/Store.hs
@@ -106,12 +106,15 @@ getConstraints name version =
 -- VERSIONS
 
 getVersions :: (MonadIO m, MonadError String m, MonadState Store m) => N.Name -> m [V.Version]
-getVersions name =
-  do  cache <- gets versionCache
-      case Map.lookup name cache of
-        Just versions -> return versions
-        Nothing ->
-            throwError noLocalVersions
-  where
-    noLocalVersions =
-        "There are no versions of package '" ++ N.toString name ++ "' on your computer."
+getVersions name = case name of
+  N.Remote _ _ ->
+    do  cache <- gets versionCache
+        case Map.lookup name cache of
+          Just versions -> return versions
+          Nothing ->
+              throwError noLocalVersions
+    where
+      noLocalVersions =
+          "There are no versions of package '" ++ N.toString name ++ "' on your computer."
+  N.Local path -> undefined
+


### PR DESCRIPTION
Just started hacking on this a bit as it was annoying me again. The idea is for `elm-package install foo`
to check if foo is a directory and then install it if it is. The dependencies in elm-package.json would look something like:

```
    "dependencies": {
        "elm-lang/core": "1.1.1 <= v < 2.0.0",
        "local:///home/kaspar/elm-project/foo": "1.0.0 <= v < 2.0.0"
    }
```

Looking for any comments in general at this point. `core` is kind of hard coded even more than the rest so it'll have to be pried out a bit (maybe a switch `--local-core` ?) before this begins to solve #91.