### PR TITLE
Fix broken link to sample elm-package.json file

### DIFF
--- a/src/Elm/Package/Description.hs
+++ b/src/Elm/Package/Description.hs
@@ -219,7 +219,7 @@ get obj field desc =
             fail $
               "Missing field " ++ show field ++ ", " ++ desc ++ ".\n" ++
               "    Check out an example " ++ Path.description ++ " file here:\n" ++
-              "    <https://github.com/evancz/elm-html/blob/master/elm_dependencies.json>"
+              "    <https://raw.githubusercontent.com/evancz/elm-html/master/elm-package.json>"
 
 
 getDependencies :: Object -> Parser [(N.Name, C.Constraint)]


### PR DESCRIPTION
It currently points to an `elm_dependencies.json`, which no longer exists on `elm-html`'s `master` branch. This updates it to point to `elm-package.json` instead.