### PR TITLE
Update optparse-applicative version (GHC 7.10)

### DIFF
--- a/elm-package.cabal
+++ b/elm-package.cabal
@@ -133,7 +133,7 @@ Executable elm-package
         http-types >= 0.7 && < 0.9,
         mtl >= 2 && < 3,
         network >= 2.4 && < 2.7,
-        optparse-applicative >= 0.8.1 && < 0.11,
+        optparse-applicative >= 0.11 && < 0.12,
         pretty,
         process >= 1 && < 2,
         text,

--- a/src/CommandLine/Arguments.hs
+++ b/src/CommandLine/Arguments.hs
@@ -163,7 +163,7 @@ installInfo =
 
 package :: Opt.Parser N.Name
 package =
-    Opt.argument N.fromString $
+    Opt.argument (maybeReader "Cannot parse PACKAGE name." N.fromString) $
         mconcat
         [ Opt.metavar "PACKAGE"
         , Opt.help "A specific package name (e.g. evancz/automaton)"
@@ -171,7 +171,7 @@ package =
 
 version :: Opt.Parser V.Version
 version =
-    Opt.argument V.fromString $
+    Opt.argument (maybeReader "Cannot parse package VERSION." V.fromString) $
         mconcat
         [ Opt.metavar "VERSION"
         , Opt.help "Specific version of a package (e.g. 1.2.0)"
@@ -185,3 +185,7 @@ yes =
         , Opt.short 'y'
         , Opt.help "Reply 'yes' to all automated prompts."
         ]
+
+maybeReader :: String -> (String -> Maybe a) -> Opt.ReadM a
+maybeReader message f =
+    Opt.eitherReader $ maybe (Left message) Right . f


### PR DESCRIPTION
With the older version cabal cannot resolve elm-package's dependencies (using GHC 7.10 / base-4.8.0.0).

```
Resolving dependencies...
cabal: Could not resolve dependencies:
trying: elm-package-0.5 (user goal)
next goal: optparse-applicative (dependency of elm-package-0.5)
rejecting: optparse-applicative-0.11.0.2, 0.11.0.1, 0.11.0 (conflict:
elm-package => optparse-applicative>=0.8.1 && <0.11)
rejecting: optparse-applicative-0.10.0, 0.9.1.1, 0.9.1, 0.9.0 (conflict:
base==4.8.0.0/installed-901..., optparse-applicative => base>=4 && <4.8)
trying: optparse-applicative-0.8.1
next goal: transformers (dependency of optparse-applicative-0.8.1)
rejecting: transformers-0.4.2.0/installed-c1a..., 0.4.3.0, 0.4.2.0, 0.4.1.0
(conflict: optparse-applicative => transformers>=0.2 && <0.4)
trying: transformers-0.3.0.0
trying: http-client-0.4.11.2 (dependency of elm-package-0.5)
trying: exceptions-0.8.0.2 (dependency of http-client-0.4.11.2)
trying: transformers-compat-0.4.0.4 (dependency of exceptions-0.8.0.2)
trying: transformers-compat-0.4.0.4:-two
rejecting: transformers-compat-0.4.0.4:-three (conflict:
transformers==0.3.0.0, transformers-compat-0.4.0.4:three =>
transformers>=0.4.1 && <0.5)
rejecting: transformers-compat-0.4.0.4:+three (manual flag can only be changed
explicitly)
Dependency tree exhaustively searched.
```