### PR TITLE
Install option defaults to yes on empty input

### DIFF
--- a/src/CommandLine/Helpers.hs
+++ b/src/CommandLine/Helpers.hs
@@ -15,7 +15,9 @@ yesOrNo =
       input <- getLine
       case input of
         "y" -> return True
+        "Y" -> return True
         "n" -> return False
+        ""  -> return True
         _   -> do putStr "Must type 'y' for yes or 'n' for no: "
                   yesOrNo
 

--- a/src/Install.hs
+++ b/src/Install.hs
@@ -187,7 +187,7 @@ addNewDependency autoYes name version description =
             ++ showDependency name newConstraint
             ++ "\n"
 
-          putStr $ "May I add that to " ++ Path.description ++ " for you? (y/n) "
+          putStr $ "May I add that to " ++ Path.description ++ " for you? [Y/n] "
           Cmd.yesOrNo
 
 

--- a/src/Install.hs
+++ b/src/Install.hs
@@ -81,7 +81,7 @@ getApproval autoYes plan =
     False ->
       do  putStrLn "Some new packages are needed. Here is the upgrade plan."
           putStrLn (Plan.display plan)
-          putStr "Do you approve of this plan? (y/n) "
+          putStr "Do you approve of this plan? [Y/n] "
           Cmd.yesOrNo
 
 


### PR DESCRIPTION
As per issue #102 I've added a default option for the package install question prompted when running `elm-package install`