### PR TITLE
Fixes cabal file to work with stack

### DIFF
--- a/elm-package.cabal
+++ b/elm-package.cabal
@@ -114,7 +114,8 @@ Executable elm-package
         Publish,
         Store,
         Utils.Http,
-        Utils.Paths
+        Utils.Paths,
+        Paths_elm_package
 
     Build-depends:
         aeson >= 0.7 && < 0.9,
@@ -126,6 +127,7 @@ Executable elm-package
         containers >= 0.3 && < 0.6,
         directory >= 1.0 && < 2.0,
         elm-compiler >= 0.15 && < 0.16,
+        elm-package,
         filepath >= 1 && < 2.0,
         HTTP >= 4000.2.5 && < 4000.3,
         http-client >= 0.3 && < 0.5,


### PR DESCRIPTION
`stack` could not resolve the needed build artifacts without adding `elm-package` as a dependency to the corresponding executable. Additionally, adds `Paths_elm_compiler` to `other-modules` in order to silence a warning from `stack`.