### PR TITLE
Call elm-make with --yes to avoid failure

### DIFF
--- a/src/Docs.hs
+++ b/src/Docs.hs
@@ -13,7 +13,7 @@ import qualified Manager
 
 generate :: Manager.Manager [Docs.Documentation]
 generate =
-  do  Cmd.run "elm-make" ["--docs=" ++ Path.documentation]
+  do  Cmd.run "elm-make" ["--yes", "--docs=" ++ Path.documentation]
       json <- liftIO (BS.readFile Path.documentation)
 
       either badJson return (Json.eitherDecode json)


### PR DESCRIPTION
I have not tested this change, but it seems like it should solve the problem that I experienced today:
```
$ elm-package diff

Error: failure when running: elm-make --docs=elm-stuff/documentation.json
elm-make: <stdin>: hGetLine: end of file
Some new packages are needed. Here is the upgrade plan.

  Install:
    elm-lang/core 2.1.0

Do you approve of this plan? (y/n) 

$
```

Because I tried to do a `diff` immediately after cloning the repo, there was nothing in elm-stuff. Notice that although it prints out `Do you approve of this plan? (y/n)` you cannot type; the program already crashed by that point and returned you to your shell.