### PR TITLE
Make Description.repo a Maybe instead of filling in a junk value

### DIFF
--- a/src/Bump.hs
+++ b/src/Bump.hs
@@ -6,6 +6,7 @@ import qualified Data.List as List
 
 import qualified Catalog
 import qualified CommandLine.Helpers as Cmd
+import qualified Data.Maybe as Maybe
 import qualified Diff.Compare as Compare
 import qualified Docs
 import qualified Elm.Docs as Docs
@@ -18,7 +19,10 @@ import qualified Manager
 bump :: Manager.Manager ()
 bump =
     do  description <- Desc.read Path.description
-        let name = Desc.name description
+        name <-
+            case Desc.name description of
+              Nothing -> throwError "Cannot bump the version number with no package name!  You may need to add a repository to your elm-package.json, something like https://github.com/USER/PROJECT.git"
+              Just n -> return n
         let statedVersion = Desc.version description
 
         newDocs <- Docs.generate
@@ -217,4 +221,3 @@ validBumps publishedVersions =
     patchPoints = Package.filterLatest Package.majorAndMinor publishedVersions
     minorPoints = Package.filterLatest Package._major publishedVersions
     majorPoint = head publishedVersions
-

--- a/src/Diff.hs
+++ b/src/Diff.hs
@@ -4,6 +4,7 @@ import Control.Monad.Error.Class (throwError)
 
 import qualified Catalog
 import qualified CommandLine.Helpers as Cmd
+import qualified Data.Maybe as Maybe
 import qualified Diff.Compare as Compare
 import qualified Diff.Display as Display
 import qualified Docs
@@ -24,7 +25,11 @@ diff :: Range -> Manager.Manager ()
 diff range =
     case range of
         LatestVsActual ->
-            do  name <- Desc.name `fmap` Desc.read Path.description
+            do  desc <- Desc.read Path.description
+                name <-
+                    case Desc.name desc of
+                      Nothing -> throwError noVersions
+                      Just n -> return n
                 newDocs <- Docs.generate
 
                 maybeVersions <- Catalog.versions name
@@ -34,7 +39,11 @@ diff range =
                 computeDiff name latestVersion newDocs Nothing
 
         Since version ->
-            do  name <- Desc.name `fmap` Desc.read Path.description
+            do  desc <- Desc.read Path.description
+                name <-
+                    case Desc.name desc of
+                      Nothing -> throwError noVersions
+                      Just n -> return n
                 newDocs <- Docs.generate
                 computeDiff name version newDocs Nothing
 

--- a/src/Elm/Package/Description.hs
+++ b/src/Elm/Package/Description.hs
@@ -26,8 +26,8 @@ import Elm.Utils ((|>))
 
 
 data Description = Description
-    { name :: Package.Name
-    , repo :: String
+    { name :: Maybe Package.Name
+    , repo :: Maybe String
     , version :: Package.Version
     , elmVersion :: C.Constraint
     , summary :: String
@@ -42,8 +42,8 @@ data Description = Description
 defaultDescription :: Description
 defaultDescription =
     Description
-    { name = Package.Name "USER" "PROJECT"
-    , repo = "https://github.com/USER/PROJECT.git"
+    { name = Nothing
+    , repo = Nothing
     , version = Package.initialVersion
     , elmVersion = C.defaultElmVersion
     , summary = "helpful summary of your project, less than 80 characters"
@@ -189,10 +189,11 @@ instance FromJSON Description where
 
             license <- get obj "license" "license information (BSD3 is recommended)"
 
-            repo <- get obj "repository" "a link to the project's GitHub repo"
-            name <- case repoToName repo of
-                      Left err -> fail err
-                      Right nm -> return nm
+            repo <- obj .:? "repository"
+            name <- case fmap repoToName repo of
+                      Just (Left err) -> fail err
+                      Just (Right nm) -> return (Just nm)
+                      Nothing -> return Nothing
 
             exposed <- get obj "exposed-modules" "a list of modules exposed to users"
 

--- a/src/Publish.hs
+++ b/src/Publish.hs
@@ -19,7 +19,10 @@ publish :: Manager.Manager ()
 publish =
   do  description <- Desc.read P.description
 
-      let name = Desc.name description
+      name <-
+          case Desc.name description of
+            Nothing -> throwError "Cannot publish with no package name!  You may need to add a repository to your elm-package.json, something like https://github.com/USER/PROJECT.git"
+            Just n -> return n
       let version = Desc.version description
 
       Cmd.out $ unwords [ "Verifying", Package.toString name, Package.versionToString version, "..." ]
@@ -67,7 +70,7 @@ verifyVersion
     -> Desc.Description
     -> Manager.Manager Bump.Validity
 verifyVersion docs description =
-  let name = Desc.name description
+  let name = Maybe.fromMaybe (Package.Name "USER" "PROJECT") (Desc.name description)
       version = Desc.version description
   in
   do  maybeVersions <- Catalog.versions name


### PR DESCRIPTION
@evancz maybe you already have another plan in mind or in progress, but here's my thought on fixing the "Upper case characters are not allowed in package names" error with `https://github.com/USER/PROJECT.git` in 0.16

A similar change would have to be made for elm-compiler.  (and any of the other tools that might parse elm-package.json)