### PR TITLE
Signal to user what is the latest version of a package if they are about to install an older one

### DIFF
--- a/src/Install.hs
+++ b/src/Install.hs
@@ -72,22 +72,22 @@ upgrade autoYes desc =
 
       let plan = Plan.create oldSolution newSolution
 
-      approve <- liftIO (getApproval autoYes plan)
+      approve <- liftIO (getApproval autoYes plan (Store.versionCache store))
 
       if approve
         then runPlan newSolution plan
         else liftIO $ putStrLn "Okay, I did not change anything!"
 
 
-getApproval :: Bool -> Plan.Plan -> IO Bool
-getApproval autoYes plan =
+getApproval :: Bool -> Plan.Plan -> Map.Map Package.Name [Package.Version] -> IO Bool
+getApproval autoYes plan versionCache =
   case autoYes || Plan.isEmpty plan of
     True ->
       return True
 
     False ->
       do  putStrLn "Some new packages are needed. Here is the upgrade plan."
-          putStrLn (Plan.display plan)
+          putStrLn (Plan.display plan (Map.map maximum versionCache))
           putStr "Do you approve of this plan? [Y/n] "
           Cmd.yesOrNo
 

--- a/src/Install.hs
+++ b/src/Install.hs
@@ -58,7 +58,9 @@ install autoYes args =
 
 upgrade :: Bool -> Desc.Description -> Manager.Manager ()
 upgrade autoYes desc =
-  do  newSolution <- Solver.solve (Desc.elmVersion desc) (Desc.dependencies desc)
+  do  store <- Store.initialStore
+
+      newSolution <- Solver.solve (Desc.elmVersion desc) (Desc.dependencies desc) store
 
       exists <- liftIO (doesFileExist Path.solvedDependencies)
 

--- a/src/Install/Plan.hs
+++ b/src/Install/Plan.hs
@@ -1,5 +1,6 @@
 module Install.Plan where
 
+import Data.Maybe
 import qualified Data.Map as Map
 
 import qualified Elm.Package.Solution as S
@@ -54,10 +55,16 @@ display (Plan installs upgrades removals) latestVersions =
 
     displayInstall (name, version) =
         Package.toString name ++ " " ++ Package.versionToString version
+        ++ versionWarning version (Map.lookup name latestVersions)
 
     displayUpgrade (name, (old, new)) =
         Package.toString name ++ " ("
         ++ Package.versionToString old ++ " => " ++ Package.versionToString new ++ ")"
+        ++ versionWarning new (Map.lookup name latestVersions)
 
     displayRemove (name, _version) =
         Package.toString name
+
+    versionWarning version latestVersion =
+        if Just version >= latestVersion then "" else
+          " (latest package version is " ++ Package.versionToString (fromJust latestVersion) ++ ")"

--- a/src/Install/Plan.hs
+++ b/src/Install/Plan.hs
@@ -39,8 +39,8 @@ isEmpty (Plan installs upgrades removals) =
 
 -- DISPLAY
 
-display :: Plan -> String
-display (Plan installs upgrades removals) =
+display :: Plan -> Map.Map Package.Name Package.Version -> String
+display (Plan installs upgrades removals) latestVersions =
     "\n"
     ++ displayCategory "Install" displayInstall installs
     ++ displayCategory "Upgrade" displayUpgrade upgrades

--- a/src/Install/Solver.hs
+++ b/src/Install/Solver.hs
@@ -20,8 +20,8 @@ import qualified Store
 -- ACTUALLY TRY TO SOLVE
 
 
-solve :: C.Constraint -> [(Package.Name, C.Constraint)] -> Manager.Manager S.Solution
-solve elmConstraint constraints =
+solve :: C.Constraint -> [(Package.Name, C.Constraint)] -> Store.Store -> Manager.Manager S.Solution
+solve elmConstraint constraints store =
   case C.check elmConstraint Compiler.version of
     LT ->
       throwError $ Error.BadElmVersion Compiler.version False elmConstraint
@@ -30,8 +30,7 @@ solve elmConstraint constraints =
       throwError $ Error.BadElmVersion Compiler.version True elmConstraint
 
     EQ ->
-      do  store <- Store.initialStore
-          (maybeSolution, newStore) <- runStateT (exploreConstraints constraints) store
+      do  (maybeSolution, newStore) <- runStateT (exploreConstraints constraints) store
           case maybeSolution of
             Just solution ->
               return solution

--- a/src/Store.hs
+++ b/src/Store.hs
@@ -1,4 +1,4 @@
-module Store (Store, getConstraints, getVersions, initialStore, readVersionCache) where
+module Store (Store, getConstraints, getVersions, initialStore, readVersionCache, versionCache) where
 
 import Control.Monad.Except (throwError)
 import Control.Monad.State (StateT)


### PR DESCRIPTION
Before:

```
> elm-package install
Some new packages are needed. Here is the upgrade plan.

  Install:
    elm-lang/core 3.0.0
    jvoigtlaender/elm-memo 1.0.0
    maxsnew/lazy 1.1.0

Do you approve of this plan? (y/n)
```

After:

```
> elm-package install
Some new packages are needed. Here is the upgrade plan.

  Install:
    elm-lang/core 3.0.0
    jvoigtlaender/elm-memo 1.0.0 (latest package version is 2.0.3)
    maxsnew/lazy 1.1.0

Do you approve of this plan? (y/n)
```

(Both in a directory whose `elm-package.json` states `"jvoigtlaender/elm-memo": "1.0.0 <= v < 2.0.0"`.)
