### PR TITLE
Print version of package being downloaded

### DIFF
--- a/src/Install.hs
+++ b/src/Install.hs
@@ -97,7 +97,7 @@ runPlan solution plan =
       -- fetch new dependencies
       Cmd.inDir Path.packagesDirectory $
           forM_ installs $ \(name, version) ->
-              do  liftIO (putStrLn ("Downloading " ++ Package.toString name))
+              do  liftIO (putStrLn ("Downloading " ++ Package.toString name ++ "@" ++ Package.versionToString version))
                   Fetch.package name version
 
       -- try to build new dependencies


### PR DESCRIPTION
For example, during CI runs, it would be really helpful if in logs like this:
```
...
elm@0.16.0 /home/travis/.nvm/versions/node/v4.1.2/lib/node_modules/elm
├── mkdirp@0.5.1 (minimist@0.0.8)
├── promise@7.0.4 (asap@2.0.3)
├── follow-redirects@0.0.7 (stream-consume@0.1.0, debug@2.2.0)
└── tar@2.2.1 (inherits@2.0.1, block-stream@0.0.8, fstream@1.0.8)
Downloading elm-lang/core
Downloading evancz/automaton
```
the packages being downloaded by Elm would be enriched by their version number, just as other tools (like `node`/`npm`) are already doing.