### PR TITLE
Request zipballs from GitHub over HTTPS

### DIFF
--- a/src/Install/Fetch.hs
+++ b/src/Install/Fetch.hs
@@ -26,7 +26,7 @@ package name@(Package.Name user _) version =
             liftIO $ renameDirectory dir (Package.versionToString version)
   where
     zipball =
-        "http://github.com/" ++ Package.toUrl name ++ "/zipball/" ++ Package.versionToString version ++ "/"
+        "https://github.com/" ++ Package.toUrl name ++ "/zipball/" ++ Package.versionToString version ++ "/"
 
 
 ifNotExists :: (MonadIO m, MonadError String m) => Package.Name -> Package.Version -> m () -> m ()


### PR DESCRIPTION
GitHub will redirect from HTTP requests to HTTPS, so we should avoid having to follow a redirect for every request.

Also, the error in #163 mentions things about TLS and ciphers, so I didn't know if this might reduce the chance of that error popping up (at least until someone who actually knows Haskell is able to implement a retry).

Thanks!