### PR TITLE
Use https for fetching zipball

### DIFF
--- a/src/Install/Fetch.hs
+++ b/src/Install/Fetch.hs
@@ -26,7 +26,7 @@ package name@(Package.Name user _) version =
             liftIO $ renameDirectory dir (Package.versionToString version)
   where
     zipball =
-        "http://github.com/" ++ Package.toUrl name ++ "/zipball/" ++ Package.versionToString version ++ "/"
+        "https://github.com/" ++ Package.toUrl name ++ "/zipball/" ++ Package.versionToString version ++ "/"
 
 
 ifNotExists :: (MonadIO m, MonadError String m) => Package.Name -> Package.Version -> m () -> m ()


### PR DESCRIPTION
Not sure if this will fix the `TlsException` issue, but seems like there's only upside and no real downside to using `https` over `http`.