### PR TITLE
Diff: No API changes message

### DIFF
--- a/src/Diff/Display.hs
+++ b/src/Diff/Display.hs
@@ -15,6 +15,7 @@ packageChanges pkgChanges@(D.PackageChanges added changed removed) =
     ++ showAdded
     ++ showRemoved
     ++ showChanged
+    ++ showAPISummary
   where
     showRemoved
         | null removed = ""
@@ -33,8 +34,14 @@ packageChanges pkgChanges@(D.PackageChanges added changed removed) =
     showChanged
         | Map.null changed = ""
         | otherwise =
-            concatMap moduleChanges (Map.toList changed)
+              concatMap moduleChanges (Map.toList changed)
 
+    showAPISummary
+        | show(D.packageChangeMagnitude pkgChanges) == "MAJOR" = ""
+        | show(D.packageChangeMagnitude pkgChanges) == "MINOR" = ""
+        | otherwise =
+            "\n\n"
+            ++ "There are no API changes between these versions.\n"
 
 moduleChanges :: (String, D.ModuleChanges) -> String
 moduleChanges (name, changes) =


### PR DESCRIPTION
This PR contains changes to the `diff` command:

Provides explicit acknowledgement that there were no API changes:

```
$ elm package diff TheSeamau5/elm-shrink 2.2.0 2.2.1

Comparing TheSeamau5/elm-shrink 2.2.0 to 2.2.1...
This is a PATCH change.
```

and then this at the bottom:

```
There are no API changes between these versions.
```

Resolves #111
