### PR TITLE
Show that install argument is directory/package-name

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ is located at [package.elm-lang.org](http://package.elm-lang.org/).
 To install a library run:
 
 ```bash
+elm-package install evancz/elm-http       # directory/package-name
 elm-package install elm-lang/html         # Install latest version
 elm-package install elm-lang/html 1.0.0   # Install version 1.0.0
 ```


### PR DESCRIPTION
I expected http to be like html (part of elm-lang) and there was nothing to show me that elm-lang is a directory (and therefore that I'd have to look for http's directory). I was trying to install http with `elm-lang/http`.