### PR TITLE
Ignore case when searching for downloaded zipballs. Fixes #214.

### DIFF
--- a/src/Install/Fetch.hs
+++ b/src/Install/Fetch.hs
@@ -117,7 +117,7 @@ fetch name@(Pkg.Name user project) version =
     do  Http.send (toZipballUrl name version) extract
         files <- liftIO $ getDirectoryContents "."
         let lowercaseFiles = map toLowerCase files
-            packageName = toLowerCase user ++ "-" ++ toLowerCase project
+            packageName = toLowerCase $ user ++ "-" ++ project
         case List.find (List.isPrefixOf packageName) lowercaseFiles of
           Nothing ->
             throwError $ Error.ZipDownloadFailed name version

--- a/src/Install/Fetch.hs
+++ b/src/Install/Fetch.hs
@@ -6,6 +6,7 @@ import Control.Concurrent.ParallelIO.Local (withPool, parallel)
 import Control.Monad.Except (liftIO, throwError)
 import qualified Codec.Archive.Zip as Zip
 import qualified Data.List as List
+import Data.Char (toLower)
 import GHC.IO.Handle (hIsTerminalDevice)
 import qualified Network.HTTP.Client as Client
 import System.Directory
@@ -115,7 +116,8 @@ fetch name@(Pkg.Name user project) version =
   ifNotExists name version $
     do  Http.send (toZipballUrl name version) extract
         files <- liftIO $ getDirectoryContents "."
-        case List.find (List.isPrefixOf (user ++ "-" ++ project)) files of
+        let lowercaseFiles = map toLowerCase files
+        case List.find (List.isPrefixOf (user ++ "-" ++ project)) lowercaseFiles of
           Nothing ->
             throwError $ Error.ZipDownloadFailed name version
 
@@ -144,3 +146,6 @@ extract request manager =
   do  response <- Client.httpLbs request manager
       let archive = Zip.toArchive (Client.responseBody response)
       Zip.extractFilesFromArchive [] archive
+
+toLowerCase :: String -> String
+toLowerCase = map toLower

--- a/src/Install/Fetch.hs
+++ b/src/Install/Fetch.hs
@@ -117,7 +117,8 @@ fetch name@(Pkg.Name user project) version =
     do  Http.send (toZipballUrl name version) extract
         files <- liftIO $ getDirectoryContents "."
         let lowercaseFiles = map toLowerCase files
-        case List.find (List.isPrefixOf (user ++ "-" ++ project)) lowercaseFiles of
+            packageName = toLowerCase user ++ "-" ++ toLowerCase project
+        case List.find (List.isPrefixOf packageName) lowercaseFiles of
           Nothing ->
             throwError $ Error.ZipDownloadFailed name version
 


### PR DESCRIPTION
Most of the discussion is in #211.

Github allows user and repository names with capital letters in them, which means that if you download the zip file for such a package, the downloaded file name will contain uppercase letters.

This patch fixes looking up zipballs for packages which have uppercase letters in the name.
