### PR TITLE
0.18 alpha: ensure elm-stuff directory exists before running plan

### DIFF
--- a/src/Install.hs
+++ b/src/Install.hs
@@ -4,7 +4,7 @@ import Control.Monad.Except (liftIO, throwError)
 import Control.Monad
 import qualified Data.List as List
 import qualified Data.Map as Map
-import System.Directory (doesFileExist, removeDirectoryRecursive)
+import System.Directory (createDirectoryIfMissing, doesFileExist, removeDirectoryRecursive)
 import System.FilePath ((</>))
 
 import qualified CommandLine.Helpers as Cmd
@@ -99,6 +99,9 @@ runPlan solution plan =
       let removals =
             Map.toList (Plan.removals plan)
             ++ Map.toList (Map.map fst (Plan.upgrades plan))
+
+      -- ensure we have the stuff directory before doing anything else
+      liftIO (createDirectoryIfMissing True Path.stuffDirectory)
 
       -- fetch new dependencies
       Fetch.everything installs


### PR DESCRIPTION
Raised by @fredcy on slack

also will fix https://github.com/elm-lang/elm-package/issues/244
# Problem
- https://github.com/elm-lang/elm-platform/blob/master/upgrade-docs/0.18.md#update-elm-packagejson suggests the easiest way to upgrade is to remove all the deps from the deps field, then install things one by one as you go along
- However, if you run `elm-package install` or `elm-make` while the deps field is empty, you will get the error: `elm-package: elm-stuff/exact-dependencies.json: openBinaryFile: does not exist (No such file or directory)`
- This fails as it tries to create the exact-dependencies file, but elm-stuff has not been created yet, as `Fetch` has not downloaded any new packages
# Solution
- Just run `createDirectoryIfMissing` on elm-stuff to ensure the elm-stuff folder exists before anything else
# Thoughts

💭  A possible long term solution would be to fill up empty deps with the default ones, but I don't think that's actually a good idea in terms of user experience.
