### PR TITLE
Update github fetch to change zipball -> legacy.zip

### DIFF
--- a/src/Install/Fetch.hs
+++ b/src/Install/Fetch.hs
@@ -132,7 +132,7 @@ fetch name@(Pkg.Name user project) version =
 toZipballUrl :: Pkg.Name -> Pkg.Version -> String
 toZipballUrl name version =
   "https://github.com/" ++ Pkg.toUrl name
-  ++ "/zipball/" ++ Pkg.versionToString version ++ "/"
+  ++ "/legacy.zip/" ++ Pkg.versionToString version ++ "/"
 
 
 ifNotExists :: Pkg.Name -> Pkg.Version -> Manager.Manager () -> Manager.Manager ()


### PR DESCRIPTION
github has changed zipball to legacy.zip in URLs.