### PR TITLE
Paths.hs: fix build failure

### DIFF
--- a/src/Utils/Paths.hs
+++ b/src/Utils/Paths.hs
@@ -12,9 +12,9 @@ json = "docs.json"
 index = "index.elm"
 listing = "public" </> "libraries.json"
 
-library name = libDir </> N.toFilePath name
+library name = libDir </> Package.toFilePath name
 
 libraryVersion :: Package.Name -> Package.Version -> FilePath
 libraryVersion name version =
-	library name </> Package.versiontoString version
+	library name </> Package.versionToString version
 


### PR DESCRIPTION
correct capitalization of versionToString

use Package.toFilePath not N.toFilePath since the import is
`import qualified Elm.Package as Package`

Fixes some minor issues from https://github.com/elm-lang/elm-package/commit/955f7c92bfe7bce0672ca727fd41dc7b4a64b149#diff-1018d219b45fd14b9344475f2c1ddbd4

The build failure is

```
[ 1 of 27] Compiling Utils.Paths      ( src/Utils/Paths.hs, dist/dist-sandbox-abceb512/build/elm-package/elm-package-tmp/Utils/Paths.o )

src/Utils/Paths.hs:15:27: error:
    Not in scope: ‘N.toFilePath’
    No module named ‘N’ is imported.

src/Utils/Paths.hs:19:26: error:
    Not in scope: ‘Package.versiontoString’
    Perhaps you meant one of these:
      ‘Package.versionToString’ (imported from Elm.Package),
      ‘Package.versionFromString’ (imported from Elm.Package)
    Module ‘Elm.Package’ does not export ‘versiontoString’.
```

CC @evancz