### PR TITLE
maybe fix compile of src/Utils/Paths.hs

### DIFF
--- a/src/Utils/Paths.hs
+++ b/src/Utils/Paths.hs
@@ -12,9 +12,8 @@ json = "docs.json"
 index = "index.elm"
 listing = "public" </> "libraries.json"
 
-library name = libDir </> N.toFilePath name
+library name = libDir </> Package.toFilePath name
 
 libraryVersion :: Package.Name -> Package.Version -> FilePath
 libraryVersion name version =
-	library name </> Package.versiontoString version
-
+	library name </> Package.versionToString version


### PR DESCRIPTION
This came out of a discussion on the elm discourse. https://discourse.elm-lang.org/t/what-prevents-elm-platform-from-using-haskell-8/666/9

Seems like this has simply been broken for a while, but, hard for me to say.